### PR TITLE
Update marlin.py to compile with latest version of platformiO

### DIFF
--- a/buildroot/share/PlatformIO/scripts/marlin.py
+++ b/buildroot/share/PlatformIO/scripts/marlin.py
@@ -17,7 +17,7 @@ def copytree(src, dst, symlinks=False, ignore=None):
             shutil.copy2(s, d)
 
 def replace_define(field, value):
-	for define in env['CPPDEFINES']:
+	for define in list(env['CPPDEFINES']):
 		if define[0] == field:
 			env['CPPDEFINES'].remove(define)
 	env['CPPDEFINES'].append((field, value))


### PR DESCRIPTION
### Requirements

changing marlin.py to enable it to compile in the latest version of platformio 
### Description

<!--

using chatGPT to fix the errors produced 

The error message indicates that a deque (double-ended queue) was mutated during iteration, causing a RuntimeError. This error occurs in the marlin.py script, specifically in the loop that iterates over the env['CPPDEFINES'] deque.

To fix this issue, you can try the following steps:

Open the marlin.py script located in /Marlin-tronxy-full-mks-tft/buildroot/share/PlatformIO/scripts/ directory.
Look for the loop that iterates over env['CPPDEFINES']. It should be around line 20 according to the error message.
Instead of directly modifying the deque while iterating over it, create a copy of the deque and iterate over the copy. This way, you can modify the original deque without causing the RuntimeError. Here's an example of how to make this modification:
python
Copy code
for define in list(env['CPPDEFINES']):
    # Perform your operations on 'define' here
By using list(env['CPPDEFINES']), you create a copy of the deque, allowing you to iterate over it without any issues.
Save the modified marlin.py script.
After making these changes, try building your project again. If the error persists or you encounter any other issues, please provide more details, such as the version of Marlin you are using, any additional error messages, and the steps you followed before encountering this error.
-->